### PR TITLE
RepairUnitクラスにcopyメソッドの追加&それに伴う微修正

### DIFF
--- a/src/main/java/jp/posl/jprophet/RepairUnit.java
+++ b/src/main/java/jp/posl/jprophet/RepairUnit.java
@@ -3,45 +3,97 @@ package jp.posl.jprophet;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import com.github.javaparser.printer.*;
 
 public class RepairUnit {
     private Node targetNode;
-    private int targetNodeIndex;
+    final private int targetNodeIndex;
     private CompilationUnit compilationUnit;
 
+    /**
+     * 修正する対象のソースコードのASTをまとめたRepairUnitクラスを作成する
+     *  
+     * @param targetNode 修正対象のステートメントを指すAST
+     * @param targetNodeIndex ソースファイル全体のASTノードをレベル順にソートした場合の修正対象ステートメントのASTのインデックス 
+     * @param compilationUnit 修正対象のステートメントを含むソースファイル全体のASTを持ったCompilationUnit
+     */
     public RepairUnit(Node targetNode, int targetNodeIndex, CompilationUnit compilationUnit){
         this.targetNode = targetNode;
         this.targetNodeIndex = targetNodeIndex;
         this.compilationUnit = compilationUnit;
+	    LexicalPreservingPrinter.setup(this.compilationUnit);
     }
 
+    /**
+     * RepairUnitインスタンスのディープコピーを作成する
+     *   
+     * @param repairUnit コピー元のRepairUnitインスタンス
+     * @return コピーされたRepairUnitインスタンス
+     */
+    public static RepairUnit copy(RepairUnit repairUnit){
+        int targetNodeIndex = repairUnit.getTargetNodeIndex();
+        CompilationUnit cu = repairUnit.getCompilationUnit();
+        CompilationUnit newCu = cu.clone();
+        Node newTargetNode = AstGenerator.findByLevelOrderIndex(newCu, targetNodeIndex).orElseThrow();
+                
+        return new RepairUnit(newTargetNode, targetNodeIndex, newCu);
+    }
+
+    /**
+     * 修正対象のステートメントのASTを返す  
+     * @return 修正対象のステートメント
+     */
     public Node getNode(){
         return this.targetNode;
     };
 
+    /**
+     * 修正対象のステートメントを含んだソースファイル全体のASTを持つCompilationUnitを返す 
+     * @return 修正対象のステートメントを含んだソースファイル全体のASTを持つCompilationUnit
+     */
     public CompilationUnit getCompilationUnit(){
         return this.compilationUnit;
     }
 
+    /**
+     * CompilationUnitから生成されるソースコードを返す
+     * @return CompilationUnitから生成されるソースコード
+     */
     public String getSourceCode() {
         //return LexicalPreservingPrinter.print(this.compilationUnit);
         return new PrettyPrinter(new PrettyPrinterConfiguration()).print(this.compilationUnit);
     }
 
-    public String toString(){
+    /**
+     * 修正対象のステートメントを文字列表現で返す 
+     * @return 修正対象のステートメントの文字列表現
+     */
+    @Override public String toString(){
         return this.targetNode.toString();
     }
 
+    /**
+     * 修正対象のステートメントのソースファイル全体における行番号を返す 
+     * @return 修正対象のステートメントのソースファイル全体における行番号
+     */
     public int getLineNumber(){
-        // TODO
+        // TODO ASTから行番号を返す．未実装
         TokenRange range = this.targetNode.getTokenRange().get();
         return 0;
     }
 
+    /**
+     * ソースファイル全体のASTノードをレベル順にソートした場合の修正対象ステートメントのASTのインデックスを返す
+     * @return ソースファイル全体のASTノードをレベル順にソートした場合の修正対象ステートメントのASTのインデックス 
+     */
     public int getTargetNodeIndex(){
         return this.targetNodeIndex; 
     }
+
+	public Object findFirst(Class<ClassOrInterfaceDefinition> class1) {
+		return null;
+	}
 
 }

--- a/src/main/java/jp/posl/jprophet/RepairUnit.java
+++ b/src/main/java/jp/posl/jprophet/RepairUnit.java
@@ -45,7 +45,7 @@ public class RepairUnit {
      * 修正対象のステートメントのASTを返す  
      * @return 修正対象のステートメント
      */
-    public Node getNode(){
+    public Node getTargetNode(){
         return this.targetNode;
     };
 

--- a/src/main/java/jp/posl/jprophet/RepairUnit.java
+++ b/src/main/java/jp/posl/jprophet/RepairUnit.java
@@ -91,9 +91,4 @@ public class RepairUnit {
     public int getTargetNodeIndex(){
         return this.targetNodeIndex; 
     }
-
-	public Object findFirst(Class<ClassOrInterfaceDefinition> class1) {
-		return null;
-	}
-
 }

--- a/src/test/java/jp/posl/jprophet/AstGeneratorTest.java
+++ b/src/test/java/jp/posl/jprophet/AstGeneratorTest.java
@@ -21,12 +21,12 @@ public class AstGeneratorTest {
         
         // ASTが取得できているか確認
         assertThat(repairUnit.size()).isEqualTo(6);
-        assertThat(repairUnit.get(0).getNode().toString()).isEqualTo("public class A {\n\n    public void a() {\n    }\n}");
-        assertThat(repairUnit.get(1).getNode().toString()).isEqualTo("A");
-        assertThat(repairUnit.get(2).getNode().toString()).isEqualTo("public void a() {\n}");
-        assertThat(repairUnit.get(3).getNode().toString()).isEqualTo("a");
-        assertThat(repairUnit.get(4).getNode().toString()).isEqualTo("void");
-        assertThat(repairUnit.get(5).getNode().toString()).isEqualTo("{\n}");
+        assertThat(repairUnit.get(0).getTargetNode().toString()).isEqualTo("public class A {\n\n    public void a() {\n    }\n}");
+        assertThat(repairUnit.get(1).getTargetNode().toString()).isEqualTo("A");
+        assertThat(repairUnit.get(2).getTargetNode().toString()).isEqualTo("public void a() {\n}");
+        assertThat(repairUnit.get(3).getTargetNode().toString()).isEqualTo("a");
+        assertThat(repairUnit.get(4).getTargetNode().toString()).isEqualTo("void");
+        assertThat(repairUnit.get(5).getTargetNode().toString()).isEqualTo("{\n}");
     }   
 
     @Test public void testForCompilationUnit(){
@@ -44,14 +44,14 @@ public class AstGeneratorTest {
         // それぞれのRepairUnitの持つコンパイルユニットが別インスタンスで，かつtargetNodeのコンパイルユニットと
         // 一致していることの確認 
         for(RepairUnit repairUnit : repairUnits){
-            assertThat(repairUnit.getNode().findRootNode()).isSameAs(repairUnit.getCompilationUnit());
+            assertThat(repairUnit.getTargetNode().findRootNode()).isSameAs(repairUnit.getCompilationUnit());
         }
         for(int i = 0; i < repairUnits.size(); i++){
             if(i == 8) continue;
             assertThat(targetUnit.getCompilationUnit()).isNotSameAs(repairUnits.get(i).getCompilationUnit());
         }
 
-        Node node = targetUnit.getNode();
+        Node node = targetUnit.getTargetNode();
         assertThat(node).isInstanceOf(VariableDeclarator.class);
         ((VariableDeclarator)node).setName("test");
         assertThat(targetUnit.getCompilationUnit().toString()).contains("test");       

--- a/src/test/java/jp/posl/jprophet/RepairCandidateGeneratorTest.java
+++ b/src/test/java/jp/posl/jprophet/RepairCandidateGeneratorTest.java
@@ -1,7 +1,7 @@
 package jp.posl.jprophet;
 
 import org.junit.Before;
-import org.junit.Test;                                                                                                                                                                  
+import org.junit.Test;
 import static org.assertj.core.api.Assertions.*;
 
 import org.mockito.InjectMocks;
@@ -15,9 +15,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
 
 
 public class RepairCandidateGeneratorTest {
@@ -42,7 +47,15 @@ public class RepairCandidateGeneratorTest {
         when(stubProject.getSourceFilePaths()).thenReturn(filePathsForTest);
 
         // 全てのRepairUnitに対して各テンプレート適用操作につきが一つのRepairUnitを返すようにモックを生成
-        List<RepairUnit> units = new ArrayList<RepairUnit>(Arrays.asList(new RepairUnit(null, 0, null))); 
+        CompilationUnit compilationUnit;
+        try{
+            compilationUnit = JavaParser.parse(Paths.get(filePath));
+        }
+        catch (IOException e){
+            e.printStackTrace();
+            return;
+        }
+        List<RepairUnit> units = new ArrayList<RepairUnit>(Arrays.asList(new RepairUnit(compilationUnit, 0, compilationUnit))); 
         when(condRefinementOperation.exec(Mockito.any(RepairUnit.class))).thenReturn(units);
         when(condIntroductionOperation.exec(Mockito.any(RepairUnit.class))).thenReturn(units);
         when(ctrlFlowIntroductionOperation.exec(Mockito.any(RepairUnit.class))).thenReturn(units);

--- a/src/test/java/jp/posl/jprophet/RepairUnitTest.java
+++ b/src/test/java/jp/posl/jprophet/RepairUnitTest.java
@@ -71,7 +71,7 @@ public class RepairUnitTest {
     @Test public void testForCopiedTargetNode() {
         RepairUnit copiedRepairUnit = RepairUnit.copy(this.repairUnits.get(2));
 
-        Node copiedTargetNode = copiedRepairUnit.getNode();
+        Node copiedTargetNode = copiedRepairUnit.getTargetNode();
         Node copiedTargetNodeFromCu = AstGenerator.findByLevelOrderIndex(copiedRepairUnit.getCompilationUnit(), 2).orElseThrow();
         Node copiedNodeFromTargetNode = copiedTargetNode.getChildNodes().get(0);
         Node copiedNodeFromCu = copiedTargetNodeFromCu.getChildNodes().get(0);

--- a/src/test/java/jp/posl/jprophet/RepairUnitTest.java
+++ b/src/test/java/jp/posl/jprophet/RepairUnitTest.java
@@ -1,0 +1,56 @@
+package jp.posl.jprophet;
+
+import jp.posl.jprophet.AstGenerator;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
+import java.util.List;
+
+import com.github.javaparser.ast.expr.SimpleName;
+
+public class RepairUnitTest {
+    private String sourceCode;
+    private List<RepairUnit> repairUnits;
+
+    @Before public void setUpRepairUnits(){
+        this.sourceCode = new StringBuilder().append("")
+            .append("public class A {\n")
+            .append("   public void a() {\n")
+            .append("   }\n")
+            .append("}\n")
+            .toString();
+
+        this.repairUnits = new AstGenerator().getAllRepairUnit(sourceCode);
+    }
+
+    @Test public void testForTargetIndex() {
+        RepairUnit repairUnit = this.repairUnits.get(2); 
+        RepairUnit copiedRepairUnit = RepairUnit.copy(repairUnit);
+
+        assertThat(copiedRepairUnit.getTargetNodeIndex()).isEqualTo(2);
+    }   
+
+
+    @Test public void testForCompilationUnit() {
+        RepairUnit repairUnit = this.repairUnits.get(0); 
+        RepairUnit copiedRepairUnit = RepairUnit.copy(repairUnit);
+
+        SimpleName methodName = repairUnit.getCompilationUnit().findFirst(SimpleName.class).get();
+        SimpleName copiedMethodName = copiedRepairUnit.getCompilationUnit().findFirst(SimpleName.class).get();
+
+        copiedMethodName.setIdentifier("test");
+        assertThat(methodName.getIdentifier()).isEqualTo("A");
+    }   
+
+    @Test public void testForTargetNode() {
+        RepairUnit repairUnit = this.repairUnits.get(2); 
+        RepairUnit copiedRepairUnit = RepairUnit.copy(repairUnit);
+
+        SimpleName copiedMethodName = copiedRepairUnit.getNode().findFirst(SimpleName.class).get();
+        SimpleName copiedMethodNameFromCu = copiedRepairUnit.getCompilationUnit().findAll(SimpleName.class).get(1);
+
+        copiedMethodName.setIdentifier("test");
+        assertThat(copiedMethodNameFromCu.getIdentifier()).isEqualTo("test");
+    }   
+}


### PR DESCRIPTION
Issue #27 に対応するPRです

大きな変更はRepairUnitクラスにcopyメソッドを追加しました．
RepairUnitクラスのディープコピーを提供します．

また，上記の実装に伴いAstGeneratorのcollectAllChiledNodesメソッドをfindByfindByLevelOrderIndexメソッドに変更し，staticメソッドとして公開しました．
ASTノードをインデックスで検索する関数です．
他のクラスでもこの関数を自由に呼び出せますが，AstGeneratorという名前のクラスが持っていて良いメソッドなのか怪しいので意見があれば頂きたいです．

また，RepairUnitのgetNodeメソッドをgetTargetNodeメソッドに変更しました．多分こっちのがいい気がします?
既にこのメソッドを利用している場合申し訳ありません