### PR TITLE
実行するテストケースの選別

### DIFF
--- a/src/main/java/jp/posl/jprophet/JProphetMain.java
+++ b/src/main/java/jp/posl/jprophet/JProphetMain.java
@@ -111,7 +111,7 @@ public class JProphetMain {
         // 学習モデルやフォルトローカライゼーションのスコアによってソート
         final List<PatchCandidate> sortedCandidates = patchEvaluator.sort(patchCandidates, suspiciousenesses, config);
         
-        final List<TestCase> testsToBeExecuted = new CoverageCollector(config.getBuildPath()).getTestCases(config);
+        final List<TestCase> testsToBeExecuted = new CoverageCollector(config.getBuildPath()).selectCollectTestCases(config);
         
         // 修正パッチ候補ごとにテスト実行
         for(PatchCandidate patchCandidate: sortedCandidates) {

--- a/src/main/java/jp/posl/jprophet/JProphetMain.java
+++ b/src/main/java/jp/posl/jprophet/JProphetMain.java
@@ -111,13 +111,13 @@ public class JProphetMain {
         // 学習モデルやフォルトローカライゼーションのスコアによってソート
         final List<PatchCandidate> sortedCandidates = patchEvaluator.sort(patchCandidates, suspiciousenesses, config);
         
-        final List<TestCase> testCase = new CoverageCollector(config.getBuildPath()).getTestCases(config);
+        final List<TestCase> testCases = new CoverageCollector(config.getBuildPath()).getTestCases(config);
         
         // 修正パッチ候補ごとにテスト実行
         for(PatchCandidate patchCandidate: sortedCandidates) {
             Project patchedProject = patchedProjectGenerator.applyPatch(patchCandidate);
             //final TestExecutorResult result = testExecutor.exec(new RepairConfiguration(config, patchedProject));
-            final TestExecutorResult result = testExecutor.exec(new RepairConfiguration(config, patchedProject), testCase);
+            final TestExecutorResult result = testExecutor.exec(new RepairConfiguration(config, patchedProject), testCases);
             testResultStore.addTestResults(result.getTestResults(), patchCandidate);
             if(result.canEndRepair()) {
                 testResultExporters.stream().forEach(exporter -> exporter.export(testResultStore));

--- a/src/main/java/jp/posl/jprophet/JProphetMain.java
+++ b/src/main/java/jp/posl/jprophet/JProphetMain.java
@@ -20,6 +20,8 @@ import jp.posl.jprophet.project.GradleProject;
 import jp.posl.jprophet.project.MavenProject;
 import jp.posl.jprophet.project.Project;
 import jp.posl.jprophet.fl.spectrumbased.SpectrumBasedFaultLocalization;
+import jp.posl.jprophet.fl.spectrumbased.TestCase;
+import jp.posl.jprophet.fl.spectrumbased.coverage.CoverageCollector;
 import jp.posl.jprophet.evaluator.PatchEvaluator;
 import jp.posl.jprophet.fl.FaultLocalization;
 import jp.posl.jprophet.fl.Suspiciousness;
@@ -109,11 +111,13 @@ public class JProphetMain {
         // 学習モデルやフォルトローカライゼーションのスコアによってソート
         final List<PatchCandidate> sortedCandidates = patchEvaluator.sort(patchCandidates, suspiciousenesses, config);
         
+        final List<TestCase> testCase = new CoverageCollector(config.getBuildPath()).getTestCases(config);
+        
         // 修正パッチ候補ごとにテスト実行
         for(PatchCandidate patchCandidate: sortedCandidates) {
             Project patchedProject = patchedProjectGenerator.applyPatch(patchCandidate);
             //final TestExecutorResult result = testExecutor.exec(new RepairConfiguration(config, patchedProject));
-            final TestExecutorResult result = testExecutor.exec(new RepairConfiguration(config, patchedProject), faultLocalization.getExecutedTests());
+            final TestExecutorResult result = testExecutor.exec(new RepairConfiguration(config, patchedProject), testCase);
             testResultStore.addTestResults(result.getTestResults(), patchCandidate);
             if(result.canEndRepair()) {
                 testResultExporters.stream().forEach(exporter -> exporter.export(testResultStore));

--- a/src/main/java/jp/posl/jprophet/JProphetMain.java
+++ b/src/main/java/jp/posl/jprophet/JProphetMain.java
@@ -111,13 +111,13 @@ public class JProphetMain {
         // 学習モデルやフォルトローカライゼーションのスコアによってソート
         final List<PatchCandidate> sortedCandidates = patchEvaluator.sort(patchCandidates, suspiciousenesses, config);
         
-        final List<TestCase> testCases = new CoverageCollector(config.getBuildPath()).getTestCases(config);
+        final List<TestCase> testsToBeExecuted = new CoverageCollector(config.getBuildPath()).getTestCases(config);
         
         // 修正パッチ候補ごとにテスト実行
         for(PatchCandidate patchCandidate: sortedCandidates) {
             Project patchedProject = patchedProjectGenerator.applyPatch(patchCandidate);
             //final TestExecutorResult result = testExecutor.exec(new RepairConfiguration(config, patchedProject));
-            final TestExecutorResult result = testExecutor.exec(new RepairConfiguration(config, patchedProject), testCases);
+            final TestExecutorResult result = testExecutor.exec(new RepairConfiguration(config, patchedProject), testsToBeExecuted);
             testResultStore.addTestResults(result.getTestResults(), patchCandidate);
             if(result.canEndRepair()) {
                 testResultExporters.stream().forEach(exporter -> exporter.export(testResultStore));

--- a/src/main/java/jp/posl/jprophet/fl/FaultLocalization.java
+++ b/src/main/java/jp/posl/jprophet/fl/FaultLocalization.java
@@ -1,14 +1,7 @@
 package jp.posl.jprophet.fl;
 
-import java.util.ArrayList;
 import java.util.List;
-
-import jp.posl.jprophet.fl.spectrumbased.TestCase;
 
 public interface FaultLocalization {
     public List<Suspiciousness> exec();
-
-    default public List<TestCase> getExecutedTests() {
-        return new ArrayList<TestCase>();
-    }
 }

--- a/src/main/java/jp/posl/jprophet/fl/spectrumbased/SpectrumBasedFaultLocalization.java
+++ b/src/main/java/jp/posl/jprophet/fl/spectrumbased/SpectrumBasedFaultLocalization.java
@@ -22,7 +22,6 @@ public class SpectrumBasedFaultLocalization implements FaultLocalization{
     List<String> sourceClassFileFqns = new ArrayList<String>();
     List<String> testClassFileFqns = new ArrayList<String>();
     Coefficient coefficient;
-    List<TestCase> testsToBeExecuted = new ArrayList<>();
 
     /**
      * ソースファイルとテストファイルをビルドして,ビルドされたクラスのFQDNを取得
@@ -52,17 +51,11 @@ public class SpectrumBasedFaultLocalization implements FaultLocalization{
             SuspiciousnessCollector suspiciousnessCollector = new SuspiciousnessCollector(testResults, this.sourceClassFileFqns, coefficient);
             suspiciousnessCollector.exec();
             suspiciousnesses = suspiciousnessCollector.getSuspiciousnesses();
-            this.testsToBeExecuted = suspiciousnessCollector.getExecutedTests();
         } catch (Exception e) {
             System.err.println(e.getMessage());
             e.printStackTrace();
             System.exit(-1);
         }
         return suspiciousnesses;
-    }
-
-    @Override
-    public List<TestCase> getExecutedTests() {
-        return this.testsToBeExecuted;
     }
 }

--- a/src/main/java/jp/posl/jprophet/fl/spectrumbased/coverage/CoverageCollector.java
+++ b/src/main/java/jp/posl/jprophet/fl/spectrumbased/coverage/CoverageCollector.java
@@ -122,7 +122,8 @@ public class CoverageCollector {
             for (String sourceFqn : config.getTargetProject().getSrcFileFqns()) {
                 List<String> testNames = testResults.getTestResults().stream()
                     .filter(t -> t.getCoverages().stream().filter(c -> c.getName().equals(sourceFqn)).findFirst().isPresent())
-                    .map(t -> t.getMethodName().substring(0,  t.getMethodName().lastIndexOf(".")))
+                    //.map(t -> t.getMethodName().substring(0,  t.getMethodName().lastIndexOf(".")))
+                    .map(t -> t.getMethodName())
                     .distinct()
                     .collect(Collectors.toList());
 

--- a/src/main/java/jp/posl/jprophet/fl/spectrumbased/coverage/CoverageCollector.java
+++ b/src/main/java/jp/posl/jprophet/fl/spectrumbased/coverage/CoverageCollector.java
@@ -111,11 +111,13 @@ public class CoverageCollector {
     }
     
     /**
-     * 正しく動くテストのみを厳選する
+     * 正しく動くテストのみを厳選する．
+     * JUnit のみでテスト実行すると，カバレッジがない，エラーメッセージがない，テストファイルでないものをテストする
+     * などが原因で失敗するテストケースが実行されてしまうため，テストを厳選している．
      * @param config 対象プロジェクトのconfig
      * @return 厳選したテストケース
      */
-    public List<TestCase> getTestCases(RepairConfiguration config) {
+    public List<TestCase> selectCollectTestCases(RepairConfiguration config) {
         try {
             TestResults testResults = this.exec(config.getTargetProject().getSrcFileFqns() , config.getTargetProject().getTestFileFqns());
             List<TestCase> testsToBeExecuted = new ArrayList<TestCase>();

--- a/src/main/java/jp/posl/jprophet/fl/spectrumbased/coverage/CoverageCollector.java
+++ b/src/main/java/jp/posl/jprophet/fl/spectrumbased/coverage/CoverageCollector.java
@@ -122,7 +122,6 @@ public class CoverageCollector {
             for (String sourceFqn : config.getTargetProject().getSrcFileFqns()) {
                 List<String> testNames = testResults.getTestResults().stream()
                     .filter(t -> t.getCoverages().stream().filter(c -> c.getName().equals(sourceFqn)).findFirst().isPresent())
-                    //.map(t -> t.getMethodName().substring(0,  t.getMethodName().lastIndexOf(".")))
                     .map(t -> t.getMethodName())
                     .distinct()
                     .collect(Collectors.toList());

--- a/src/main/java/jp/posl/jprophet/fl/spectrumbased/coverage/CoverageCollector.java
+++ b/src/main/java/jp/posl/jprophet/fl/spectrumbased/coverage/CoverageCollector.java
@@ -120,7 +120,7 @@ public class CoverageCollector {
     public List<TestCase> selectCollectTestCases(RepairConfiguration config) {
         try {
             TestResults testResults = this.exec(config.getTargetProject().getSrcFileFqns() , config.getTargetProject().getTestFileFqns());
-            List<TestCase> testsToBeExecuted = new ArrayList<TestCase>();
+            List<TestCase> correctTestCases = new ArrayList<TestCase>();
             for (String sourceFqn : config.getTargetProject().getSrcFileFqns()) {
                 List<String> testNames = testResults.getTestResults().stream()
                     .filter(t -> t.getCoverages().stream().filter(c -> c.getName().equals(sourceFqn)).findFirst().isPresent())
@@ -128,9 +128,9 @@ public class CoverageCollector {
                     .distinct()
                     .collect(Collectors.toList());
 
-                testsToBeExecuted.add(new TestCase(sourceFqn, testNames));
+                correctTestCases.add(new TestCase(sourceFqn, testNames));
             }
-            return testsToBeExecuted;
+            return correctTestCases;
         } catch (Exception e) {
             return new ArrayList<TestCase>();
         }

--- a/src/main/java/jp/posl/jprophet/fl/spectrumbased/coverage/CoverageCollector.java
+++ b/src/main/java/jp/posl/jprophet/fl/spectrumbased/coverage/CoverageCollector.java
@@ -272,7 +272,7 @@ public class CoverageCollector {
                 .collect(Collectors.toList());
 
             final TestResult testResult = new TestResult(testMethodFQN, wasFailed, coverages);
-            if (hasErrorMassage && !description.getMethodName().equals("initializationError")) {
+            if (coverages.size() > 0 && hasErrorMassage && !description.getMethodName().equals("initializationError")) {
                 testResults.add(testResult);
             }
         }

--- a/src/main/java/jp/posl/jprophet/fl/spectrumbased/statement/SuspiciousnessCollector.java
+++ b/src/main/java/jp/posl/jprophet/fl/spectrumbased/statement/SuspiciousnessCollector.java
@@ -9,7 +9,6 @@ import jp.posl.jprophet.fl.spectrumbased.coverage.Coverage;
 import jp.posl.jprophet.fl.spectrumbased.coverage.TestResults;
 import jp.posl.jprophet.fl.spectrumbased.coverage.Coverage.Status;
 import jp.posl.jprophet.fl.Suspiciousness;
-import jp.posl.jprophet.fl.spectrumbased.TestCase;
 
 /**
  * ステートメント(行)ごとの疑惑値の計算
@@ -20,7 +19,6 @@ public class SuspiciousnessCollector {
     final private List<String> sourceFqns;
     final private TestResults testResults;
     final private Coefficient coefficient;
-    private List<TestCase> testsToBeExecuted = new ArrayList<TestCase>();
 
     /**
      * テスト結果(カバレッジ情報を含む)から,全てのテスト対象ファイルの各行ごとの疑惑値を計算
@@ -41,14 +39,6 @@ public class SuspiciousnessCollector {
 
         for (String sourceFqn : sourceFqns){
             List<Coverage> failedCoverages = new ArrayList<Coverage>();     
-
-            List<String> testNames = testResults.getTestResults().stream()
-                .filter(t -> t.getCoverages().stream().filter(c -> c.getName().equals(sourceFqn)).findFirst().isPresent())
-                .map(t -> t.getMethodName().substring(0,  t.getMethodName().lastIndexOf(".")))
-                .distinct()
-                .collect(Collectors.toList());
-
-            testsToBeExecuted.add(new TestCase(sourceFqn, testNames));
 
             testResults.getFailedTestResults().stream()
                 .map(t -> t.getCoverages()
@@ -76,10 +66,6 @@ public class SuspiciousnessCollector {
                 this.suspiciousnesses.add(calculateSuspiciousnessOfLine(sourceFqn, failedCoverages, successedCoverages, i));
             }
         }
-    }
-
-    public List<TestCase> getExecutedTests() {
-        return this.testsToBeExecuted;
     }
 
     /**

--- a/src/main/java/jp/posl/jprophet/test/executor/TestThread.java
+++ b/src/main/java/jp/posl/jprophet/test/executor/TestThread.java
@@ -14,9 +14,9 @@ public class TestThread extends Thread {
     public boolean isSuccess;
 
     /**
-     * 
+     * クラスに含まれる全てのテストを実行
      * @param junitCore
-     * @param testClass
+     * @param testClass テストするクラス
      */
     public TestThread(JUnitCore junitCore, Class<?> testClass){
         this.junitCore = junitCore;
@@ -25,6 +25,12 @@ public class TestThread extends Thread {
         this.isSingleRun = false;
     }
 
+    /**
+     * クラス内のメソッドを指定して実行
+     * @param junitCore
+     * @param testClass テストするクラス
+     * @param methodName testClassに含まれるテストメソッド
+     */
     public TestThread(JUnitCore junitCore, Class<?> testClass, String methodName){
         this.junitCore = junitCore;
         this.testClass = testClass;

--- a/src/main/java/jp/posl/jprophet/test/executor/TestThread.java
+++ b/src/main/java/jp/posl/jprophet/test/executor/TestThread.java
@@ -1,6 +1,7 @@
 package jp.posl.jprophet.test.executor;
 
 import org.junit.runner.JUnitCore;
+import org.junit.runner.Request;
 
 /**
  * junitによるテスト実行をスレッドで実行する
@@ -8,6 +9,8 @@ import org.junit.runner.JUnitCore;
 public class TestThread extends Thread {
     private JUnitCore junitCore;
     private Class<?> testClass;
+    private String methodName;
+    private boolean isSingleRun;
     public boolean isSuccess;
 
     /**
@@ -19,11 +22,24 @@ public class TestThread extends Thread {
         this.junitCore = junitCore;
         this.testClass = testClass;
         this.isSuccess = false;
+        this.isSingleRun = false;
+    }
+
+    public TestThread(JUnitCore junitCore, Class<?> testClass, String methodName){
+        this.junitCore = junitCore;
+        this.testClass = testClass;
+        this.isSuccess = false;
+        this.methodName = methodName;
+        this.isSingleRun = true;
     }
 
     @Override
     public void run(){
-        this.isSuccess = junitCore.run(testClass).wasSuccessful();
+        if (isSingleRun) {
+            this.isSuccess = junitCore.run(Request.method(testClass, methodName)).wasSuccessful();
+        } else {
+            this.isSuccess = junitCore.run(testClass).wasSuccessful();
+        }
     }
 
     public boolean getIsSuccess(){


### PR DESCRIPTION
- TestExecutor の実行前に jacoco を使って正しく動くテストのみを取り出す
- CoverageCollector に getTestCases メソッドを追加し，JProphetMain のパッチのソート後に実行することで，正しく動くテストケースを選別する
- 正しく動くテストをクラス単位ではなく，メソッド単位で選別するように変更(2020/12/17)