### PR TITLE
Fix incorrect class name generation from file path when path contains /java

### DIFF
--- a/src/main/java/jp/posl/jprophet/project/MavenProject.java
+++ b/src/main/java/jp/posl/jprophet/project/MavenProject.java
@@ -174,7 +174,7 @@ public class MavenProject implements Project {
     private String buildSrcFileFqn(String filePath){
         final String gradleSrcPath = "/src/main/java/";
         final String srcDirPath = this.rootPath + gradleSrcPath;
-        return filePath.replace(srcDirPath, "").replace("/", ".").replace(".java", "");
+        return filePath.replace(srcDirPath, "").replace(".java", "").replace("/", ".");
     }
 
     /**


### PR DESCRIPTION
The original implementation of this method led to incorrect class name generation when the file path contained the substring /java.

Previously, a file path like "com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java" would incorrectly generate the class name "com.amazon.sqsmessaging.AmazonSQSExtendedClient". This was due to the premature removal of the /java segment.